### PR TITLE
used _baseUrl.AbsoluteUri instead of _baseUrl to avoid included port …

### DIFF
--- a/Saule/Serialization/ResourceSerializer.cs
+++ b/Saule/Serialization/ResourceSerializer.cs
@@ -133,7 +133,7 @@ namespace Saule.Serialization
             // to preserve back compatibility if Self is enabled, then we also render it. Or if TopSelf is enabled
             if (_resource.LinkType.HasFlag(LinkType.TopSelf) || _resource.LinkType.HasFlag(LinkType.Self))
             {
-                result.Add("self", _baseUrl);
+                result.Add("self", _baseUrl.AbsoluteUri);
             }
 
             var queryStrings = new PaginationQuery(_paginationContext);

--- a/Tests/Serialization/ResourceSerializerTests.cs
+++ b/Tests/Serialization/ResourceSerializerTests.cs
@@ -115,14 +115,14 @@ namespace Tests.Serialization
             var job = result["data"]["relationships"]["job"]["links"];
             var friends = result["data"]["relationships"]["friends"]["links"];
 
-            var self = result["links"]["self"].Value<Uri>().AbsolutePath;
+            var self = result["links"]["self"].Value<string>();
             var jobSelf = job["self"].Value<Uri>().AbsolutePath;
             var jobRelated = job["related"].Value<Uri>().AbsolutePath;
             var friendsSelf = friends["self"].Value<Uri>().AbsolutePath;
             var friendsRelated = friends["related"].Value<Uri>().AbsolutePath;
             var included = result["included"][0]["links"]["self"].Value<Uri>().AbsolutePath;
 
-            Assert.Equal("/api/people/abc", self);
+            Assert.EndsWith("/api/people/abc", self);
             Assert.Equal("/api/people/abc/relationships/employer/", jobSelf);
             Assert.Equal("/api/people/abc/employer/", jobRelated);
             Assert.Equal("/api/people/abc/relationships/friends/", friendsSelf);

--- a/Tests/Serialization/UrlConstructionTests.cs
+++ b/Tests/Serialization/UrlConstructionTests.cs
@@ -33,11 +33,11 @@ namespace Tests.Serialization
 
             var jobLinks = result["data"]?["relationships"]?["job"]?["links"];
 
-            var selfLink = result["links"].Value<Uri>("self")?.PathAndQuery;
+            var selfLink = result["links"].Value<string>("self");
             var jobSelfLink = jobLinks?.Value<Uri>("self")?.PathAndQuery;
             var jobRelationLink = jobLinks?.Value<Uri>("related")?.PathAndQuery;
 
-            Assert.Equal("/api/people/123?a=b&c=d", selfLink);
+            Assert.EndsWith("/api/people/123?a=b&c=d", selfLink);
             Assert.Equal("/api/people/123/relationships/employer/", jobSelfLink);
             Assert.Equal("/api/people/123/employer/", jobRelationLink);
         }
@@ -80,9 +80,22 @@ namespace Tests.Serialization
             var result = target.Serialize();
             _output.WriteLine(result.ToString());
 
-            var selfLink = result["links"].Value<Uri>("self").AbsolutePath;
+            var selfLink = result["links"].Value<string>("self");
 
-            Assert.Equal("/api/people/123", selfLink);
+            Assert.EndsWith("/api/people/123", selfLink);
+        }
+
+        [Fact(DisplayName = "Adds top level self link without any port")]
+        public void SelfLinkNoPort()
+        {
+            var target = new ResourceSerializer(Get.Person(), new PersonResource(),
+                new Uri("http://localhost:80/api/people/123"), DefaultPathBuilder, null, null, null);
+            var result = target.Serialize();
+            _output.WriteLine(result.ToString());
+
+            var selfLink = result["links"].Value<string>("self");
+
+            Assert.Equal("http://localhost/api/people/123", selfLink);
         }
 
         [Fact(DisplayName = "Adds top level self link if only LinkType.TopSelf is specified")]
@@ -93,9 +106,9 @@ namespace Tests.Serialization
             var result = target.Serialize();
             _output.WriteLine(result.ToString());
 
-            var selfLink = result["links"].Value<Uri>("self").AbsolutePath;
+            var selfLink = result["links"].Value<string>("self");
 
-            Assert.Equal("/api/people/123", selfLink);
+            Assert.EndsWith("/api/people/123", selfLink);
 
             Assert.Null(result["data"][0]["links"]);
         }


### PR DESCRIPTION
…number in the self link (#206)

* used _baseUrl.AbsoluteUri instead of _baseUrl to avoid included port number in the self link

* fixed newer test